### PR TITLE
Fix typo: use `with` keyword for `Iterator` description

### DIFF
--- a/content/docs/language.md
+++ b/content/docs/language.md
@@ -222,7 +222,7 @@ even infer which traits are needed in generic function signatures.
 // Something is iterable if we can call `next` on it and
 // get either Some element and the rest of the iterator or
 // None and we finish iterating
-trait Iterator it -> elem =
+trait Iterator it -> elem with
     next: it -> Maybe (it, elem)
 
 first_equals_two it =


### PR DESCRIPTION
Hi! I've been reading through Ante with great interest.
I noticed what seems to be a small typo, so I opened a PR to fix it.
Thanks for your work!